### PR TITLE
Podfile needs a target to install the pods

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '9.0'
 use_frameworks!
 
-target 'grokSwiftREST_1.2' do
+target 'grokSwiftREST' do
 use_frameworks!
 pod 'Alamofire', '~> 3.3'
 pod 'SwiftyJSON', '~> 2.3'

--- a/Podfile
+++ b/Podfile
@@ -2,9 +2,12 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '9.0'
 use_frameworks!
 
+target 'grokSwiftREST_1.2' do
+use_frameworks!
 pod 'Alamofire', '~> 3.3'
 pod 'SwiftyJSON', '~> 2.3'
 pod 'PINRemoteImage', '~> 2.1'
 pod 'Locksmith', '~> 2.0'
 pod 'XLForm', '~> 3.1'
 pod 'BRYXBanner', '~> 0.5'
+end


### PR DESCRIPTION
It is necessary that the Pods you want to install, belong to a target. I have edited the _Podfile_ otherwise no one is able to run _pod install_ and use the demo code
